### PR TITLE
Add alias so that ./craft works with this module

### DIFF
--- a/src/VolumePermissions.php
+++ b/src/VolumePermissions.php
@@ -1,6 +1,8 @@
 <?php
 namespace Imarc\Craft\Modules;
 
+use Craft;
+
 
 /**
  * Volume Permissions module class.
@@ -15,6 +17,7 @@ class VolumePermissions extends \yii\base\Module
      */
     public function init()
     {
+    	Craft::setAlias('@Imarc', __DIR__);
         $prop = new \ReflectionProperty('League\Flysystem\Adapter\Local', 'permissions');
         $prop->setAccessible(true);
         $prop->setValue([


### PR DESCRIPTION
Without this, you get an error along the lines of

```
Exception 'yii\base\InvalidArgumentException' with message 'Invalid path alias: @Imarc/Craft/Modules/controllers'
```